### PR TITLE
Recreating shadow when child gets smaller.

### DIFF
--- a/library/src/main/java/com/dd/ShadowLayout.java
+++ b/library/src/main/java/com/dd/ShadowLayout.java
@@ -17,6 +17,9 @@ public class ShadowLayout extends FrameLayout {
     private float mDx;
     private float mDy;
 
+    private boolean mInvalidateShadowOnSizeChanged = true;
+    private boolean mForceInvalidateShadow = false;
+
     public ShadowLayout(Context context) {
         super(context);
         initView(context, null);
@@ -35,8 +38,18 @@ public class ShadowLayout extends FrameLayout {
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
-        if(w > 0 && h > 0) {
+        if(w > 0 && h > 0 && (getBackground() == null || mInvalidateShadowOnSizeChanged || mForceInvalidateShadow)) {
+            mForceInvalidateShadow = false;
             setBackgroundCompat(w, h);
+        }
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        if (mForceInvalidateShadow) {
+            mForceInvalidateShadow = false;
+            setBackgroundCompat(right-left, bottom-top);
         }
     }
 
@@ -131,5 +144,15 @@ public class ShadowLayout extends FrameLayout {
     @Override
     protected int getSuggestedMinimumHeight() {
         return 0;
+    }
+
+    public void setInvalidateShadowOnSizeChanged(boolean invalidateShadowOnSizeChanged) {
+        this.mInvalidateShadowOnSizeChanged = invalidateShadowOnSizeChanged;
+    }
+
+    public void invalidateShadow() {
+        this.mForceInvalidateShadow = true;
+        requestLayout();
+        invalidate();
     }
 }

--- a/library/src/main/java/com/dd/ShadowLayout.java
+++ b/library/src/main/java/com/dd/ShadowLayout.java
@@ -122,4 +122,14 @@ public class ShadowLayout extends FrameLayout {
 
         return output;
     }
+
+    @Override
+    protected int getSuggestedMinimumWidth() {
+        return 0;
+    }
+
+    @Override
+    protected int getSuggestedMinimumHeight() {
+        return 0;
+    }
 }


### PR DESCRIPTION
Hi,
in current implementation of `ShadowLayout` it looks like it suppose to recreate its shadow background on every size change:

``` java
@Override
protected void onSizeChanged(int w, int h, int oldw, int oldh) {
    super.onSizeChanged(w, h, oldw, oldh);
    if(w > 0 && h > 0) {
        setBackgroundCompat(w, h);
    }
}
```

Lets say we have a `TextView` with string "**Long label**" inside the `ShadowLayout`, both measured as `wrap_content`. After child is measured `ShadowLayout` will generate shadow bitmap matching the size of text.

When we change the text to "**Very long label**" measuring phase is triggered again so the `onSizeChanged` of `ShadowLayout` will be triggered. Bigger shadow background will be created for wider label and everything is fine.
![very_long_label](https://cloud.githubusercontent.com/assets/6815900/6879422/e27eb8a4-d4f4-11e4-8720-d9097572a763.png)

However when we would change text to "**Label**", `TextView` will be smaller, but overall width of `ShadowLayout` is a maximum of "largest child's width" and "background width". Since there is already old background set (rendered for wider child) - `ShadowLayout` will keep the original size and won't recreate the shadow background for smaller child.
![label](https://cloud.githubusercontent.com/assets/6815900/6879423/e7d6e934-d4f4-11e4-9482-19b3d85cb9d2.png)

We need to override following methods to let `ShadowLayout` ignore its current background when measuring self:

``` java
@Override
protected int getSuggestedMinimumWidth() {
    return 0;
}

@Override
protected int getSuggestedMinimumHeight() {
    return 0;
}
```

Here is the original implementation from `View` class:

``` java
protected int getSuggestedMinimumWidth() {
    return (mBackground == null) ? mMinWidth : max(mMinWidth, mBackground.getMinimumWidth());
}

protected int getSuggestedMinimumHeight() {
    return (mBackground == null) ? mMinHeight : max(mMinHeight, mBackground.getMinimumHeight());
}
```
